### PR TITLE
feat: use native AbortController when possible

### DIFF
--- a/abort-controller.browser.js
+++ b/abort-controller.browser.js
@@ -1,0 +1,4 @@
+'use strict'
+/* eslint-env browser */
+
+module.exports = AbortController

--- a/abort-controller.js
+++ b/abort-controller.js
@@ -1,0 +1,9 @@
+'use strict'
+
+// Electron has `AbortController` and should use that instead of custom.
+// Works around: https://github.com/mysticatea/abort-controller/issues/24
+module.exports = typeof AbortController === 'function'
+  /* eslint-env browser */
+  /* istanbul ignore next */
+  ? require('./abort-controller.browser')
+  : require('abort-controller')

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const AbortController = require('abort-controller')
+const AbortController = require('./abort-controller')
 
 /**
  * Takes an array of AbortSignals and returns a single signal.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "any-signal",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Combines an array of AbortSignals into a single signal that is aborted when any signal is",
   "main": "index.js",
   "files": [
-    "index.js"
+    "index.js",
+    "abort-controller.js",
+    "abort-controller.browser.js"
   ],
   "scripts": {
     "test": "npm run lint && nyc --reporter=lcov --reporter=text ava --verbose",
@@ -13,6 +15,9 @@
   "keywords": [],
   "author": "Jacob Heun",
   "license": "MIT",
+  "browser": {
+    "./abort-controller.js": "./abort-controller.browser.js"
+  },
   "dependencies": {
     "abort-controller": "^3.0.0"
   },


### PR DESCRIPTION
This works around https://github.com/mysticatea/abort-controller/issues/24 in order to unblock https://github.com/ipfs/js-ipfs-utils/pull/60