### PR TITLE
feat: Use globally available AbortController

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-const { AbortController } = globalThis
-
 /**
  * Takes an array of AbortSignals and returns a single signal.
  * If any signals are aborted, the returned signal will be aborted.


### PR DESCRIPTION
As far as I know, getting `AbortController` from `globalThis` is no longer required, if Node.js v16 is the target. `AbortController` is readily available there.

Additionally, current pattern makes it almost impossible to polyfill `AbortController`, as most of the times, the code in `index.js` is executed before a polyfill could be executed.

Using vanilla `AbortController` works fine on engines that support native `AbortController` as well as when polyfilled.