### PR TITLE
fix: allow undefined values in signals list

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-declare function anySignal(signals: AbortSignal[]): AbortSignal;
+declare function anySignal(signals: (AbortSignal | null | undefined)[]): AbortSignal;
 
 export {anySignal};
 


### PR DESCRIPTION
The implementation already checks if the values in the anySignal([]) array are undefined or not. Update the TypeScript types to allow undefined or null values in the array.