### PR TITLE
feat: Add `clear` method for a composite signal

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,9 @@
-declare function anySignal(signals: AbortSignal[]): AbortSignal;
+interface CompositeSignal extends AbortSignal {
+    clear(): void
+}
 
-export {anySignal};
+declare function anySignal(signals: Array<AbortSignal | undefined | null>): AbortSignal;
+
+export {anySignal, type CompositeSignal};
 
 export default anySignal;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,9 @@
-interface CompositeSignal extends AbortSignal {
+interface ClearableSignal extends AbortSignal {
     clear(): void
 }
 
-declare function anySignal(signals: Array<AbortSignal | undefined | null>): AbortSignal;
+declare function anySignal(signals: Array<AbortSignal | undefined | null>): ClearableSignal;
 
-export {anySignal, type CompositeSignal};
+export {anySignal, type ClearableSignal};
 
 export default anySignal;

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
  * Takes an array of AbortSignals and returns a single signal.
  * If any signals are aborted, the returned signal will be aborted.
  * @param {Array<AbortSignal>} signals
- * @returns {AbortSignal}
+ * @returns {CompositeSignal}
  */
 function anySignal (signals) {
   const controller = new globalThis.AbortController()
@@ -25,7 +25,21 @@ function anySignal (signals) {
     signal.addEventListener('abort', onAbort)
   }
 
-  return controller.signal
+  function clear () {
+    for (const signal of signals) {
+      if (!signal || !signal.removeEventListener) continue
+      signal.removeEventListener('abort', onAbort)
+    }
+  }
+
+  return new Proxy(controller.signal, {
+    get (target, p) {
+      if (p === 'clear') {
+        return clear
+      }
+      return target[p]
+    }
+  })
 }
 
 module.exports = anySignal

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
  * Takes an array of AbortSignals and returns a single signal.
  * If any signals are aborted, the returned signal will be aborted.
  * @param {Array<AbortSignal>} signals
- * @returns {CompositeSignal}
+ * @returns {ClearableSignal}
  */
 function anySignal (signals) {
   const controller = new globalThis.AbortController()

--- a/test.js
+++ b/test.js
@@ -3,9 +3,35 @@ const pDefer = require('p-defer')
 const anySignal = require('./')
 const { AbortController } = globalThis
 
+// AbortSignal, with an introspection on number of "abort" event listeners
+function withHandlersCount (signal) {
+  let abortHandlers = 0
+  return new Proxy(signal, {
+    get (target, p) {
+      if (p === 'addEventListener') {
+        return function (...args) {
+          abortHandlers += 1
+          target[p].apply(target, args)
+        }
+      }
+      if (p === 'removeEventListener') {
+        return function (...args) {
+          abortHandlers -= 1
+          target[p].apply(target, args)
+        }
+      }
+      if (p === '_abortHandlers') {
+        return abortHandlers
+      }
+      return target[p]
+    }
+  })
+}
+
 test('should abort from any signal', async t => {
   const controllers = [...new Array(5)].map(() => new AbortController())
-  const signal = anySignal(controllers.map(c => c.signal))
+  const signals = controllers.map(c => withHandlersCount(c.signal))
+  const signal = anySignal(signals)
   t.is(signal.aborted, false)
   const deferred = pDefer()
   let abortCount = 0
@@ -14,12 +40,17 @@ test('should abort from any signal', async t => {
     deferred.resolve()
   })
 
+  // Handlers added
+  signals.every(s => t.is(s._abortHandlers, 1))
+
   const randomController = controllers[Math.floor(Math.random() * controllers.length)]
   randomController.abort()
 
   await deferred.promise
   t.is(abortCount, 1)
   t.is(signal.aborted, true)
+  // Handlers removed
+  signals.every(s => t.is(s._abortHandlers, 0))
 })
 
 test('ignores non signals', async t => {
@@ -71,4 +102,34 @@ test('should abort if a provided signal is already aborted', t => {
 
   const signal = anySignal(controllers.map(c => c.signal))
   t.is(signal.aborted, true)
+})
+
+test('explicitly clear handlers', t => {
+  const controllers = [...new Array(5)].map(() => new AbortController())
+  const signals = controllers.map(c => withHandlersCount(c.signal))
+  const signal = anySignal(signals)
+  // No aborts
+  t.is(signal.aborted, false)
+  // Each signal got an "abort" listener
+  signals.every(s => t.is(s._abortHandlers, 1))
+  signal.clear()
+  // No aborts still
+  t.is(signal.aborted, false)
+  // Each signal is clear of listeners
+  signals.every(s => t.is(s._abortHandlers, 0))
+})
+
+test('abort after clear', t => {
+  const controllers = [...new Array(5)].map(() => new AbortController())
+  const signals = controllers.map(c => withHandlersCount(c.signal))
+  const signal = anySignal(signals)
+  t.is(signal.aborted, false)
+  // Clear event handlers
+  signal.clear()
+
+  const randomController = controllers[Math.floor(Math.random() * controllers.length)]
+  randomController.abort()
+
+  // No handlers means there are no events propagated to the composite `signal`
+  t.is(signal.aborted, false)
 })


### PR DESCRIPTION
Not quite optimal, and I would prefer it all to be TypeScript code, yet here it goes. At least, as a provisionary PR open to critique.

Now `anySignal` function returns `AbortSignal` with a twist. If you call `signal.clear()`, it clears all the event handlers set up on the constituent AbortSignals. An example in #23 could be modified to not cause any memory leaks:

```typescript
class Loader {
  shutdownController = new AbortController()

  async load(id: string, options: { signal: AbortSignal }) {
    const compositeSignal = anySignal([this.shutdownController.signal, options.signal])
    try {
      await doSomething(compositeSignal)
      return "Success!"
    } finally {
      compositeSignal.clear()
    }
  }
}
```