### PR TITLE
fix: allow increasing number of listeners in node

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,6 +137,10 @@
   },
   "devDependencies": {
     "aegir": "^38.1.8",
-    "p-defer": "^4.0.0"
+    "p-defer": "^4.0.0",
+    "wherearewe": "^2.0.1"
+  },
+  "browser": {
+    "node:events": false
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,23 +39,8 @@ export function anySignal (signals: Array<AbortSignal | undefined | null>): Clea
     }
   }
 
-  // @ts-expect-error Proxy is not a ClearableSignal
-  return new Proxy(controller.signal, {
-    get (target, p) {
-      if (p === 'clear') {
-        return clear
-      }
+  const signal = controller.signal as ClearableSignal
+  signal.clear = clear
 
-      // @ts-expect-error cannot use string to index target type
-      const value = target[p]
-
-      if (typeof value === 'function') {
-        return function (...args: any[]): any {
-          return value.apply(target, args)
-        }
-      }
-
-      return value
-    }
-  })
+  return signal
 }

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from 'aegir/chai'
 import pDefer from 'p-defer'
+import { isNode, isElectronMain } from 'wherearewe'
 import { anySignal } from '../src/index.js'
 const { AbortController } = globalThis
 
@@ -140,5 +141,19 @@ describe('any-signal', () => {
 
     // No handlers means there are no events propagated to the composite `signal`
     expect(signal).to.have.property('aborted', false)
+  })
+
+  it('should be able to increase max number of listeners on returned signal', async () => {
+    if (!isNode && !isElectronMain) {
+      return
+    }
+
+    // @ts-expect-error setMaxListeners is missing from @types/node
+    const { setMaxListeners } = await import('node:events')
+    const controllers = [...new Array(5)].map(() => new AbortController())
+    const signals = controllers.map(c => c.signal)
+    const signal = anySignal(signals)
+
+    setMaxListeners(Infinity, signal)
   })
 })


### PR DESCRIPTION
Node often shows this warning:

```
(node:33263) MaxListenersExceededWarning: Possible EventTarget memory leak detected. 11 abort listeners added to [AbortSignal]. Use events.setMaxListeners() to increase limit
```

The way round it is to use the `setMaxListeners` function from the `events` module.

Unfortunately returning a `Proxy` object to add the `.clear` function doesn't work with `setMaxLiseners` and fails with:

```
TypeError: The "eventTargets" argument must be an instance of EventEmitter or EventTarget. Received [AbortSignal]
```

The change here is to just add the `.clear` property to the returned `AbortSignal`.