### PR TITLE
feat: add signal abort reason

### DIFF
--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -156,4 +156,22 @@ describe('any-signal', () => {
 
     setMaxListeners(Infinity, signal)
   })
+
+  it('should be abort with custom signal reason', async () => {
+    if (!isNode && !isElectronMain) {
+      return
+    }
+
+    class TimeoutError extends Error {}
+    class CancelError extends Error {}
+
+    const c1 = new AbortController()
+    const c2 = new AbortController()
+
+    const signal = anySignal([c1.signal, c2.signal])
+
+    c1.abort(new TimeoutError('timeout'))
+    c2.abort(new CancelError('cancel'))
+    expect(signal.reason instanceof TimeoutError).to.equal(true)
+  })
 })

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -172,6 +172,7 @@ describe('any-signal', () => {
 
     c1.abort(new TimeoutError('timeout'))
     c2.abort(new CancelError('cancel'))
+    expect(signal.reason instanceof CancelError).to.equal(false)
     expect(signal.reason instanceof TimeoutError).to.equal(true)
   })
 })


### PR DESCRIPTION
If I can know which signal aborted, it would be nice