### PR TITLE
feat: report abort reason

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,12 @@ export function anySignal (signals: Array<AbortSignal | undefined | null>): Clea
   const controller = new globalThis.AbortController()
 
   function onAbort (): void {
-    controller.abort()
+    const reason = signals
+      .filter(s => s?.aborted === true)
+      .map(s => s?.reason)
+      .pop()
+
+    controller.abort(reason)
 
     for (const signal of signals) {
       if (signal?.removeEventListener != null) {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -156,4 +156,21 @@ describe('any-signal', () => {
 
     setMaxListeners(Infinity, signal)
   })
+
+  it('should report the reason for aborting', async () => {
+    class TimeoutError extends Error {}
+    class CancelError extends Error {}
+
+    const c1 = new AbortController()
+    const c2 = new AbortController()
+
+    const signal = anySignal([c1.signal, c2.signal])
+
+    c1.abort(new TimeoutError('timeout'))
+    c2.abort(new CancelError('cancel'))
+
+    expect(signal).to.have.property('aborted', true)
+    expect(signal).to.have.property('reason').that.is.not.an.instanceOf(CancelError)
+    expect(signal).to.have.property('reason').that.is.an.instanceOf(TimeoutError)
+  })
 })


### PR DESCRIPTION
On abort, find the first aborted signal and use it's reason to abort the internal controller.

Reports more useful error messages than "The signal was aborted without reason"